### PR TITLE
Fix nil error when step is greater than 1

### DIFF
--- a/lib/heroku/command/mongo.rb
+++ b/lib/heroku/command/mongo.rb
@@ -120,7 +120,7 @@ module Heroku::Command
 
       def step(count)
         step  = count / 100000 # 1/1000 of a percent
-        step  = 1 if step == 0
+        step == 0 ? 1 : step
       end
 
       Help.group 'Mongo' do |group|


### PR DESCRIPTION
Snippet of the error this fixes:

 !    Heroku client internal error.
 !    Search for help at: https://help.heroku.com
 !    Or report a bug at: https://github.com/heroku/heroku/issues/new

```
Error:       nil can't be coerced into Fixnum (TypeError)
Backtrace:   /Users/kris/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:112:in `%'
             /Users/kris/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:112:in `display_progress'
             /Users/kris/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:41:in `block (2 levels) in transfer'
             /Users/kris/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/mongo-1.10.2/lib/mongo/cursor.rb:335:in `each'
             /Users/kris/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:39:in `each_with_index'
             /Users/kris/.heroku/plugins/heroku-mongo-sync/lib/heroku/command/mongo.rb:39:in `block in transf
```
